### PR TITLE
Use correct snappy package name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+snappy
+cramjam


### PR DESCRIPTION
## Summary
- update the requirements file to depend on the correct `snappy` package instead of `python-snappy`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce8c938d108322ab5839419a300a73